### PR TITLE
Added namespace variable for Servicemonitor object

### DIFF
--- a/helm/values/values.yaml
+++ b/helm/values/values.yaml
@@ -1036,7 +1036,7 @@ metrics:
     enabled: true
     ## @param metrics.serviceMonitor.namespace Specify the namespace in which the serviceMonitor resource will be created
     ##
-    namespace: "monitoring"
+    namespace: "${service_monitor_namespace}"
     ## @param metrics.serviceMonitor.interval Specify the interval at which metrics should be scraped
     ##
     interval: 30s

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,7 @@ resource "helm_release" "rabbitmq" {
       rabbitmq_volume_size      = var.rabbitmq_config.volume_size,
       erlangcookie_password     = random_password.erlangcookie_password.result,
       rabbitmq_exporter_enabled = var.rabbitmq_exporter_enabled
+      service_monitor_namespace = var.namespace
 
     }),
     var.rabbitmq_config.values_yaml


### PR DESCRIPTION

What: Added variables for servicemonitor

Why: The namespace to create servicemonitor was hardcoded hence resources are conflicting if the module is called in Demo Dev and Prod modules. 